### PR TITLE
Querying

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,21 @@ $ ./bin/tas
 
 ## TODO
 
-* [ ] Directive REPL
+* [x] Directive REPL
   * [x] quit
   * [x] process-file
-  * [ ] query
+  * [x] query
   * [x] ignore empty input lines
   * [x] echo entire input, not just directive
 
-* [ ] Querying
-  * [ ] empty data set
-  * [ ] all matches
-  * [ ] limit matches to 10
+* [x] Querying
+  * [x] empty data set
+  * [x] all matches
+  * [x] limit matches to 10
 
 * [ ] Processing files
-  * [ ] trie insertion
-  * [ ] associate nodes with movie titles
+  * [x] trie insertion
+  * [x] support multiple movies with the same key
   * [x] concurrent updates
   * [ ] better title tokenization; ignore hyphens, split on other punctuation
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ ./bin/tas
   * [ ] trie insertion
   * [ ] associate nodes with movie titles
   * [x] concurrent updates
+  * [ ] better title tokenization; ignore hyphens, split on other punctuation
 
 * [ ] profile memory footprint
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,3 +33,7 @@ dependencies {
     'org.mockito:mockito-core:2.0.43-beta',
     'info.solidsoft.mockito:mockito-java8:2.0.0-beta'
 }
+
+compileJava {
+  options.compilerArgs << "-Xlint:unchecked"
+}

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,8 @@ repositories {
 }
 
 dependencies {
-  compile 'com.google.inject:guice:4.+'
+  compile 'com.google.inject:guice:4.+',
+    'com.googlecode.concurrent-trees:concurrent-trees:2.5.+'
 
   testCompile 'junit:junit:4.+',
     'org.assertj:assertj-core:3.+',

--- a/src/main/java/Movie.java
+++ b/src/main/java/Movie.java
@@ -1,4 +1,8 @@
-class Movie {
+import java.util.Comparator;
+
+class Movie implements Comparable {
+  static final Comparator<Movie> COMPARATOR = new MovieComparator();
+
   final String title;
   final String yearReleased;
   final String countryCode;
@@ -12,5 +16,44 @@ class Movie {
   @Override
   public String toString() {
     return String.format("%s (%s) (%s)", title, yearReleased, countryCode);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null) return false;
+    if (this == o) return true;
+    return o instanceof Movie ? this.equalsMovie((Movie)o) : false;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 7;
+    result = 19 * result + title.toLowerCase().hashCode();
+    result = 19 * result + yearReleased.hashCode();
+    result = 19 * result + countryCode.hashCode();
+    return result;
+  }
+
+  boolean equalsMovie(Movie m) {
+    return this.title.toLowerCase().equals(m.title.toLowerCase())
+      && this.yearReleased.equals(m.yearReleased)
+      && this.countryCode.equals(m.countryCode);
+  }
+
+  public int compareTo(Object o) {
+    if (o == null) throw new NullPointerException();
+    if (this == o) return 0;
+    if (!(o instanceof Movie)) throw new ClassCastException();
+    return COMPARATOR.compare(this, (Movie)o);
+  }
+}
+
+class MovieComparator implements Comparator<Movie> {
+  public int compare(Movie a, Movie b) {
+    int r = 0;
+    r = r == 0 ? a.title.compareToIgnoreCase(b.title) : r;
+    r = r == 0 ? a.yearReleased.compareTo(b.yearReleased) : r;
+    r = r == 0 ? a.countryCode.compareTo(b.countryCode) : r;
+    return r ;
   }
 }

--- a/src/main/java/Movies.java
+++ b/src/main/java/Movies.java
@@ -1,15 +1,25 @@
 import java.util.*;
 import java.util.concurrent.ConcurrentSkipListSet;
+import javax.inject.Singleton;
+import com.googlecode.concurrenttrees.radix.*;
+import com.googlecode.concurrenttrees.radix.node.concrete.SmartArrayBasedNodeFactory;
 
+@Singleton
 class Movies {
-  private final NavigableSet<Movie> movies;
+  private final RadixTree<Movie> titles;
 
   Movies() {
-    this.movies = new ConcurrentSkipListSet(new MovieComparator());
+    this.titles = new ConcurrentRadixTree<>(new SmartArrayBasedNodeFactory());
   }
 
   public void add(Movie movie) {
-    this.movies.add(movie);
+    for (String w : movie.title.toLowerCase().split("\\s")) {
+      titles.putIfAbsent(w, movie);
+    }
+  }
+
+  public Iterable<Movie> startingWith(String s) {
+    return titles.getValuesForKeysStartingWith(s);
   }
 }
 

--- a/src/main/java/Movies.java
+++ b/src/main/java/Movies.java
@@ -18,8 +18,17 @@ class Movies {
     }
   }
 
-  public Iterable<Movie> startingWith(String s) {
-    return titles.getValuesForKeysStartingWith(s);
+  public Iterable<Movie> startingWith(String s, int maxHits) {
+    Collection<Movie> matches = new TreeSet<>(new MovieComparator());
+
+    for (CharSequence key : titles.getKeysStartingWith(s)) {
+      Movie movie = titles.getValueForExactKey(key);
+      if (matches.add(movie) && matches.size() >= maxHits) {
+        break;
+      }
+    }
+
+    return Collections.unmodifiableCollection(matches);
   }
 }
 

--- a/src/main/java/QueryDirective.java
+++ b/src/main/java/QueryDirective.java
@@ -2,6 +2,8 @@ import java.io.PrintWriter;
 import javax.inject.Inject;
 
 class QueryDirective implements Directive {
+  private static final int MAX_HITS = 10;
+
   private final PrintWriter out;
   private final Movies movies;
 
@@ -16,7 +18,7 @@ class QueryDirective implements Directive {
   }
 
   public DirectiveResult apply(String parameters) {
-    for (Movie m : movies.startingWith(parameters.toLowerCase())) {
+    for (Movie m : movies.startingWith(parameters.toLowerCase(), MAX_HITS)) {
       out.println(String.format("%s\t%s\t%s", m.yearReleased, m.countryCode, m.title));
     }
     return DirectiveResult.CONTINUE;

--- a/src/main/java/QueryDirective.java
+++ b/src/main/java/QueryDirective.java
@@ -2,7 +2,7 @@ import java.io.PrintWriter;
 import javax.inject.Inject;
 
 class QueryDirective implements Directive {
-  private static final int MAX_HITS = 10;
+  private static final int MAX_RESULTS = 10;
 
   private final PrintWriter out;
   private final Movies movies;
@@ -18,7 +18,7 @@ class QueryDirective implements Directive {
   }
 
   public DirectiveResult apply(String parameters) {
-    for (Movie m : movies.startingWith(parameters.toLowerCase(), MAX_HITS)) {
+    for (Movie m : movies.startingWith(parameters.toLowerCase(), MAX_RESULTS)) {
       out.println(String.format("%s\t%s\t%s", m.yearReleased, m.countryCode, m.title));
     }
     return DirectiveResult.CONTINUE;

--- a/src/main/java/QueryDirective.java
+++ b/src/main/java/QueryDirective.java
@@ -2,11 +2,13 @@ import java.io.PrintWriter;
 import javax.inject.Inject;
 
 class QueryDirective implements Directive {
-  private final PrintWriter err;
+  private final PrintWriter out;
+  private final Movies movies;
 
   @Inject
-  QueryDirective(@StandardError PrintWriter err) {
-    this.err = err;
+  QueryDirective(@StandardOutput PrintWriter out, Movies movies) {
+    this.out = out;
+    this.movies = movies;
   }
 
   public final String name() {
@@ -14,7 +16,9 @@ class QueryDirective implements Directive {
   }
 
   public DirectiveResult apply(String parameters) {
-    err.println(name() + " unimplemented");
+    for (Movie m : movies.startingWith(parameters.toLowerCase())) {
+      out.println(String.format("%s\t%s\t%s", m.yearReleased, m.countryCode, m.title));
+    }
     return DirectiveResult.CONTINUE;
   }
 }


### PR DESCRIPTION
Spike to add querying of movies.

* [x] `query` directive queries `Movies`
* [x] radix tree for prefix searching
* [x] concurrent skip list to associate multiple movies with a word/token

## Known Issues

* needs test coverage
* tokenizing on whitespace only too simplistic, e.g. "The Lego Movie" and "Lego: The Adventures of Clutch Powers" have "Lego" and "Lego:" as separate tokens
* storing a reference to a `Set` with references to `Movie` instances within radix tree nodes almost certainly uses too much memory for huge datasets